### PR TITLE
Add Hyperledger Composer install notes and cleanup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,32 @@
+[HC]: /etc/notes/HyperledgerComposer/README.md "Hyperledger Composer README file"
+
 # BEEMS
 
-Blockchain-based Enterprise Entity Management System. 
+Blockchain-based Enterprise Entity Management System.
 
 Project in collaboration with MIMOS.
 
 ## Repository cloning
 
-Using git-scm at terminal: `git clone https://github.com/RaikireHiuduo/BEEMS.git`
+Using `git-scm` at terminal: `git clone https://github.com/RaikireHiuduo/BEEMS.git`
 
 ## Usage instruction
+
+### Starting and ending the network
+
+Assumption that the user has read and based the installation from the [Hyperledger Composer README notes][HC]
+
+```bash
+# Start the Hyperledger Fabric network.
+cd ~/fabric-tools
+./startFabric.sh
+
+# Shutdown the Hyperledger Fabric network.
+cd ~/fabric-tools
+./stopFabric.sh
+```
+
+### Running the application
 
 (To be added...)
 
@@ -18,6 +36,12 @@ Currently closed to a closed project development team and MIMOS team. Regardless
 
 ## Development
 
-### Hyperledger Fabric
+Main development environment is located in the [/main folder](/main "main folder").
 
-[Check out the README.md file for Hyperledger Fabric installation guide and notes in the etc/notes/ folder.](./etc/notes/HyperledgerFabric/README.md "Hyperledger Fabric README file")
+Please be reminded the team will be using only VSCode with Hyperledger Composer extension and Terminal exclusively in uBuntu 16.04 (Xenial) LTS.
+
+### Hyperledger Fabric Composer
+
+[Check out the README.md file for Hyperledger Composer installation guide and notes in the /etc/notes/ folder.][HC]
+
+[Tutorial for Hyperledger Composer provided by Hyperledger Composer docs team](https://hyperledger.github.io/composer/tutorials/developer-tutorial.html "Developer Tutorial for creating a Hyperledger Composer solution")

--- a/etc/notes/CHEATCODE.md
+++ b/etc/notes/CHEATCODE.md
@@ -44,7 +44,7 @@ Notes:-
   - It is depending on the size of the updates.
 - It is suggested to run it daily to update the Hyperledger Fabric to the latest version.
   - It is also suggested to run it at least twice in case of bad connection breaking one part of the download. If there is no problem, it should be a quick check without any noticable downloading actions and done.
-  
+
 ## Development
 
 ### Node.js
@@ -57,6 +57,6 @@ Only do this when there is `package.json` and `.js` files to run.
 npm install
 ```
 
-You will have a `node_modules` folder. Whenever possible, always delete this before running `npm install` for the sake of sanity. 
+You will have a `node_modules` folder. Whenever possible, always delete this before running `npm install` for the sake of sanity.
 
-`WARN` notice can _usually_ be ignored safely unless it was developed manually in which it is the responsibility of the developer to try to fix it. 
+`WARN` notice can _usually_ be ignored safely unless it was developed manually in which it is the responsibility of the developer to try to fix it.

--- a/etc/notes/HyperledgerComposer/README.md
+++ b/etc/notes/HyperledgerComposer/README.md
@@ -1,0 +1,70 @@
+[HCI]: https://hyperledger.github.io/composer/installing/development-tools.html "Installing and developing with Hyperledger Composer by Hyperledger Composer"
+
+# Hyperledger Composer
+
+**[Always refer to the official documentation of Hyperledger Composer](https://hyperledger.github.io/composer/introduction/introduction.html "Introduction to Hyperledger Composer")**
+
+Read "[Installing and developing with Hyperledger Composer by Hyperledger Composer][HCI]" for installation help.
+
+## Installation notes
+
+- As per the documentation, the playground is optional and can be safely ignored.
+- Since the Hyperledger Composer is based on Hyperledger Fabric, the Hyperledger Fabric code will need to be downloaded too.
+  - The good news is that the nice folks of the documentation has prepared shell scripts for the installation from scratch to the end, especially for uBuntu users.
+
+### Installation code used
+
+**WARNING:** Information is accurate to documentation by time of writing. Please be reminded **these commands may not work or inaccurate in the future**. As such, it is highly suggested to read the [official documentation on the proper way to install instead][HCI].
+
+Important notes:-
+
+- Run on `uBuntu 16.04 LTS`.
+- `cURL` must be installed. Please install `cURL` first before continuing.
+
+Run on `Terminal`:-
+
+```bash
+# Download the prerequistics for Hyperledger Fabric (script for uBuntu).
+curl -O https://hyperledger.github.io/composer/prereqs-ubuntu.sh
+chmod u+x prereqs-ubuntu.sh
+./prereqs-ubuntu.sh
+
+# Logout and then, login. Alternatively, just shutdown and then starting up manually or restart would be fine.
+
+# Download and install the tools for Hyperledger Composer.
+npm install -g composer-cli
+npm install -g generator-hyperledger-composer
+npm install -g composer-rest-server
+npm install -g yo
+
+# Get the one-stop composer-fabric toolkits and put it at user's home.
+mkdir ~/fabric-tools && cd ~/fabric-tools
+curl -O https://raw.githubusercontent.com/hyperledger/composer-tools/master/packages/fabric-dev-servers/fabric-dev-servers.zip
+unzip fabric-dev-servers.zip
+
+# Download the Hyperledger Fabric (WARNING: Huge filesize). Consider reruning the script again if having a bad connection.
+cd ~/fabric-tools
+./downloadFabric.sh
+
+# Start the Hyperledger Fabric network and create an entry-point as admin (one-time only)
+cd ~/fabric-tools
+./startFabric.sh
+./createPeerAdminCard.sh
+
+# Shutdown the Hyperledger Fabric network.
+cd ~/fabric-tools
+./stopFabric.sh
+```
+
+Note for Composer: Only rerun `./createPeerAdminCard.sh` (create an admin card) if you did `./teardownFabric.sh` (destroy the whole fabric network and the admin card). Only run `./teardownFabric.sh` after `./stopFabric.sh`.
+
+## Expected results
+
+- `fabric-tools` at `~/` (user's home or `$HOME`) path. Important and very useful.
+- Hyperledger Fabric images in Docker (test with `docker images`).
+- Hyperledger Composer in cli is active (test with `composer -v`).
+- All the prerequistics tools and extensions as per the documentation for the tools and images above.
+
+## Next steps
+
+- Download [Microsoft's Visual Studio Code (VSCode)](https://code.visualstudio.com/ "Microsoft's Visual Studio Code") and download the `Hyperledger Composer` extension inside VSCode.


### PR DESCRIPTION
- Adding the Hyperledger Composer installation notes.
- Clean up most of the documentation to refer to Hyperledger Composer rather than the Hyperledger Fabric directly.